### PR TITLE
Update LightGallery link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Zoom module for [lightGallery](http://sachinchoolur.github.io/lightGallery/)
 A customizable, modular, responsive, lightbox gallery plugin for jQuery.
-![lightgallery](https://raw.githubusercontent.com/sachinchoolur/lightGallery/master/lib/lg.png)
+![lightgallery](https://github.com/sachinchoolur/lightGallery)
 
 Main features
 ---


### PR DESCRIPTION
As it is, the link returns a 404 error message. The changes only changes the URL so it goes on the Github project page